### PR TITLE
Implemented automatic documentation generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,13 +7,42 @@ on:
       - 'release/**'
     paths:
       - 'serverless.yml'
-      - 'layer/**'
       - 'lambdas/**'
+      - 'docs/**'
 jobs:
-  deploy:
+  generate-docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
+      with:
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: api
+        template: docs/template.md
+      env:
+        CFD_PUBLIC_DOMAIN: ${{ secrets.CFD_PUBLIC_DOMAIN }}
+        APP_VERSION: ${{ secrets.APP_VERSION }}
+  deploy:
+    runs-on: ubuntu-latest
+    needs: generate-docs
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+        registry-url: https://registry.npmjs.org/
+    - name: Pull latest commit
+      run: |
+        git config pull.rebase false
+        git pull
     - name: Install dependencies
       run: npm i
     - name: serverless check

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,29 @@
+![](https://img.shields.io/github/package-json/v/kaskadi/kaskadi-entry-point-api)
+![](https://img.shields.io/badge/code--style-standard-blue)
+![](https://img.shields.io/github/license/kaskadi/kaskadi-entry-point-api?color=blue)
+
+**GitHub Actions workflows status**
+
+[![](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-entry-point-api/deploy?label=deployed&logo=Amazon%20AWS)](https://github.com/kaskadi/kaskadi-entry-point-api/actions?query=workflow%3Adeploy)
+[![](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-entry-point-api/build?label=build&logo=mocha)](https://github.com/kaskadi/kaskadi-entry-point-api/actions?query=workflow%3Abuild)
+[![](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-entry-point-api/syntax-check?label=syntax-check&logo=serverless)](https://github.com/kaskadi/kaskadi-entry-point-api/actions?query=workflow%3Asyntax-check)
+
+**CodeClimate**
+
+[![](https://img.shields.io/codeclimate/maintainability/kaskadi/kaskadi-entry-point-api?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-entry-point-api)
+[![](https://img.shields.io/codeclimate/tech-debt/kaskadi/kaskadi-entry-point-api?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-entry-point-api)
+[![](https://img.shields.io/codeclimate/coverage/kaskadi/kaskadi-entry-point-api?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-entry-point-api)
+
+**LGTM**
+
+[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/kaskadi-entry-point-api?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/kaskadi-entry-point-api/?mode=list&logo=LGTM)
+
+<!-- You can add badges inside of this section if you'd like -->
+
+****
+
+<!-- automatically generated documentation will be placed in here -->
+{{>main}}
+<!-- automatically generated documentation will be placed in here -->
+
+<!-- You can customize this template as you'd like! -->

--- a/lambdas/serve/serverless.yml
+++ b/lambdas/serve/serverless.yml
@@ -9,8 +9,20 @@ events:
       path: /
       method: get
       cors: true
+      kaskadi-docs:
+        description: This endpoint returns the required HTML content to start the Kaskadi application.
+        queryStringParameters:
+          - key: host
+            description: Hosting server for all apps/assets.
+            default: Kaskadi public CDN
   # and to all subsequent paths
   - http:
       path: /{proxy+}
       method: get
       cors: true
+      kaskadi-docs:
+        description: This endpoint returns the required HTML content to start the Kaskadi application.
+        queryStringParameters:
+          - key: host
+            description: Hosting server for all apps/assets.
+            default: Kaskadi public CDN

--- a/tools/add-lambda/data/serverless.yml
+++ b/tools/add-lambda/data/serverless.yml
@@ -1,5 +1,6 @@
 handler: lambdas/{{name}}/{{name}}.handler
 name: {{name}}
+# customize as needed to connect your lambda function to layers
 layers:
   - { Ref: ApiLayerLambdaLayer }
 package:
@@ -11,3 +12,21 @@ events:
       method: {{method}}
       path: {{path}}
       cors: true
+      # custom fields allowing you to describe your endpoint in order to automatically document it
+      kaskadi-docs:
+        description: placeholder endpoint # describe what this endpoint is used for
+        # this field helps you describe any query string parameter accepted by this endpoint
+        queryStringParameters:
+          - key: key1
+            description: first key
+          - key: key2
+            description: second key
+            default: 35 # you can give a default value
+        # this field helps you describe the body expected by your endpoint
+        body:
+          - key: param1
+            description: first body param
+            default: 'hello'
+          - key: param2
+            description: second body param
+            default: true

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,11 +1,8 @@
-# Layer
-echo "installing layer"
-echo "changing directory"
-cd layer/nodejs
-echo $(pwd)
-echo "installing dependencies"
-npm i
-echo "done"
-echo "cleaning up"
-cd ../..
-echo $(pwd)
+#!/bin/bash
+
+if [ -d "layer" ] && [ -f "layer/nodejs/package.json" ]
+  then
+    cd layer/nodejs || exit
+    npm i
+    cd ../../
+fi


### PR DESCRIPTION
**Changes description**
Implemented automatic documentation generation using `action-generate-docs` GitHub action.

**New features**
- _docs template:_ template for documentation generation located under `docs/template.md`

**Updated features**
- _`deploy` workflow:_ now includes a `generate-docs` step which automatically generate documentation using `action-generate-docs` and a template located under `docs/template.md`
- _endpoints config file:_ now includes custom `kaskadi-docs` field for documentation generation
- _install script:_ updated install script to handle cases where no layer exists
- _`add-lambda` tool:_ added placeholder `kaskadi-docs` field in base config file