### PR TITLE
Split deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,3 @@
-# ATTENTION: no deployment should be done until serverless.yml is properly setup
 name: deploy
 on:
   push:
@@ -7,44 +6,23 @@ on:
       - 'release/**'
     paths:
       - 'serverless.yml'
+      - 'package.json'
       - 'lambdas/**'
-      - 'docs/**'
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_KEY_SECRET }}
   CFD_PUBLIC_DOMAIN: ${{ secrets.CFD_PUBLIC_DOMAIN }}
   APP_VERSION: ${{ secrets.APP_VERSION }}
 jobs:
-  generate-docs:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Import GPG key
-      uses: crazy-max/ghaction-import-gpg@v2
-      with:
-        git_user_signingkey: true
-        git_commit_gpgsign: true
-      env:
-        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
-        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
-    - name: Generate documentation
-      uses: kaskadi/action-generate-docs@master
-      with:
-        type: api
-        template: docs/template.md
   deploy:
     runs-on: ubuntu-latest
-    needs: generate-docs
+    if: github.repository != 'kaskadi/template-kaskadi-api' # this is done to skip deploy workflow to avoid the common Serverless API Gateway error when the stack hasn't been deployed yet (template won't be deployed)
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
         node-version: 12
         registry-url: https://registry.npmjs.org/
-    - name: Pull latest commit
-      run: |
-        git config pull.rebase false
-        git pull
     - name: Install dependencies
       run: npm i
     - name: serverless check

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,44 @@
+name: generate-docs
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    paths:
+      - 'serverless.yml'
+      - 'package.json'
+      - 'docs/**'
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_KEY_SECRET }}
+  CFD_PUBLIC_DOMAIN: ${{ secrets.CFD_PUBLIC_DOMAIN }}
+  APP_VERSION: ${{ secrets.APP_VERSION }}
+jobs:
+  generate-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+        registry-url: https://registry.npmjs.org/
+    - name: Install dependencies
+      run: npm i
+    - name: serverless check
+      if: github.repository != 'kaskadi/template-kaskadi-api' # this is done to skip this step to avoid the common Serverless API Gateway error when the stack hasn't been deployed yet (template won't be deployed)
+      uses: serverless/github-action@master
+      with:
+        args: deploy --noDeploy
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
+      with:
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: api
+        template: docs/template.md

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   syntax-check:
     runs-on: ubuntu-latest
+    if: github.repository != 'kaskadi/template-kaskadi-api' # this is done to skip deploy workflow to avoid the common Serverless API Gateway error when the stack hasn't been deployed yet (template won't be deployed)
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/docs/template.md
+++ b/docs/template.md
@@ -4,9 +4,10 @@
 
 **GitHub Actions workflows status**
 
-[![](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-entry-point-api/deploy?label=deployed&logo=Amazon%20AWS)](https://github.com/kaskadi/kaskadi-entry-point-api/actions?query=workflow%3Adeploy)
-[![](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-entry-point-api/build?label=build&logo=mocha)](https://github.com/kaskadi/kaskadi-entry-point-api/actions?query=workflow%3Abuild)
-[![](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-entry-point-api/syntax-check?label=syntax-check&logo=serverless)](https://github.com/kaskadi/kaskadi-entry-point-api/actions?query=workflow%3Asyntax-check)
+[![Deploy status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-entry-point-api/deploy?label=deployed&logo=Amazon%20AWS)](https://github.com/kaskadi/kaskadi-entry-point-api/actions?query=workflow%3Adeploy)
+[![Build status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-entry-point-api/build?label=build&logo=mocha)](https://github.com/kaskadi/kaskadi-entry-point-api/actions?query=workflow%3Abuild)
+[![Syntax check status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-entry-point-api/syntax-check?label=syntax-check&logo=serverless)](https://github.com/kaskadi/kaskadi-entry-point-api/actions?query=workflow%3Asyntax-check)
+[![Docs generation status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-entry-point-api/generate-docs?label=docs&logo=read-the-docs)](https://github.com/kaskadi/kaskadi-entry-point-api/actions?query=workflow%3Agenerate-docs)
 
 **CodeClimate**
 


### PR DESCRIPTION
**Changes description**
Extracted `generate-docs` step from `deploy` workflow into a separate workflow. Both workflows check for syntax error in `serverless.yml`. This was done to prevent deployment for failing in case the workflow couldn't generate the documentation automatically (we don't need an up to date documentation to deploy resources).

**New features**
- _`generate-docs` workflow:_ former `generate-docs` step of `deploy` workflow. Now also checks for syntax error in config file.

**Updated features**
- _`deploy` workflow:_ removed `generate-docs` step and fixed triggers.
- _conditional step/job run:_ `deploy`, `generate-docs` and `syntax-check` all checks (either at job or at step level) if the calling repository is the template. If yes they would skip the associated job/step (Serverless task). This is done to avoid running a Serverless related task that will fail because of the common Serverless API Gateway error (`stack id does not exist`) because the template hasn't actually been deployed.